### PR TITLE
Add fake redirect() method

### DIFF
--- a/src/Joomlatools/Joomla/Application.php
+++ b/src/Joomlatools/Joomla/Application.php
@@ -376,6 +376,15 @@ class Application extends JApplicationCli
     {
         return false;
     }
+    
+    /**
+     * Does nothing
+     * 
+     * This method is a stub; Some extensions use JFactory::getApplication()->redirect() inside their installscripts (such as NoNumberInstallerHelper)
+     */
+    public function redirect()
+    {
+    }
 
     /**
      * Flush the media version to refresh versionable assets


### PR DESCRIPTION
Some extensions use JFactory::getApplication()->redirect() inside their installscripts (for example NoNumberInstallerHelper),
and this supresses the error "Call to undefined function Joomlatools\Composer\Application::redirect()"

=> Workaround makes it possible to install extensions like com_advancedmodules, plg_system_articlesanywhere etc. via composer
